### PR TITLE
Display publication reference for models

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,13 @@
   "version": "1.0.0",
   "author": "M@TE team",
   "dependencies": {
+    "@citation-js/plugin-csl": "^0.7.2",
     "@fortawesome/fontawesome-free": "^6.4.2",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "bulma": "^0.9.4",
+    "citation-js": "^0.7.4",
     "gatsby": "^5.8.1",
     "gatsby-image": "^3.11.0",
     "gatsby-plugin-fontawesome-css": "^1.2.0",

--- a/src/components/Citation.js
+++ b/src/components/Citation.js
@@ -1,0 +1,90 @@
+import { Cite } from "@citation-js/core"
+import "@citation-js/plugin-csl"
+import "@citation-js/plugin-doi"
+import React from "react"
+
+class Citation extends React.Component {
+  render() {
+    const {
+      data,
+      html,
+    } = this.props
+    const __html = (
+      html
+      ? html
+      : getHtml(data)
+    )
+    return (
+      <>
+        {
+          __html &&
+          <span
+            dangerouslySetInnerHTML={{
+              __html
+            }}
+          />
+        }
+      </>
+    )
+  }
+}
+
+const getHtml = (data) => {
+  if (!data) {
+    return data
+  }
+  const cite = new Cite(cleanData(data))
+  const bib = cite.format("bibliography", {format: "html", style: "apa"})
+  return replaceDois({html: bib, style: "apa"})
+}
+
+const cleanData = (data) => {
+  if (data.container_title) {
+    data["container-title"] = data.container_title
+  }
+  if (data.issued?.date_parts) {
+    data.issued["date-parts"] = data.issued.date_parts
+  }
+  return data
+}
+
+// Taken from gatsby-source-publications
+// https://github.com/bacor/gatsby-source-publications/blob/main/gatsby-node.mjs#L12
+function replaceDois({ html, style }) {
+  if (style === "apa") {
+    const regex = /(https\:\/\/doi\.org\/([^<]+)\<\/div\>)/gm;
+    const match = html.match(regex);
+    if (match) {
+      const url = match[0].replace("</div>", "");
+      const doi = url.replace("https://doi.org/", "");
+      const anchor = `
+        <a href="${url}">
+          <span className="doi-label">DOI:</span>
+          <span className="doi-value">${doi}</span>
+        </a>`;
+      return html.replace(match[0], anchor);
+    }
+  }
+  return html;
+}
+
+const extractData = (data) => {
+  if (!data) {
+    return null
+  }
+  return {
+    author: data.author,
+    "container-title": data.journal,
+    DOI: data.doi,
+    issue: data.issue,
+    issued: {
+      "date-parts": [[data.year]]
+    },
+    title: data.title,
+    type: "article-journal",
+    volume: data.volume,
+  }
+}
+
+export default Citation
+export { extractData, getHtml, replaceDois, cleanData }

--- a/src/components/Citation.js
+++ b/src/components/Citation.js
@@ -68,23 +68,5 @@ function replaceDois({ html, style }) {
   return html;
 }
 
-const extractData = (data) => {
-  if (!data) {
-    return null
-  }
-  return {
-    author: data.author,
-    "container-title": data.journal,
-    DOI: data.doi,
-    issue: data.issue,
-    issued: {
-      "date-parts": [[data.year]]
-    },
-    title: data.title,
-    type: "article-journal",
-    volume: data.volume,
-  }
-}
-
 export default Citation
-export { extractData, getHtml, replaceDois, cleanData }
+export { getHtml, replaceDois, cleanData }

--- a/src/pages/models/corcho-2022-collision/index.md
+++ b/src/pages/models/corcho-2022-collision/index.md
@@ -48,11 +48,39 @@ authors:
     ORCID: 0000-0003-3685-174X
     affiliation: Research School of Earth Sciences, Australian National University
 associated_publication:
-  title: The Role of Lithospheric-Deep Mantle Interactions on the Style and Stress Evolution of Arc-Continent Collision
-  journal: Geochemistry, Geophysics, Geosystems
-  publisher: American Geophysical Union
-  doi: 10.1029/2022GC010386
-  url: https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2022GC010386
+  DOI: 10.1029/2022gc010386
+  URL: http://dx.doi.org/10.1029/2022gc010386
+  author:
+    - family: Rodríguez Corcho
+      given: Andrés Felipe
+      sequence: first
+    - family: Polanco
+      given: Sara
+      sequence: additional
+    - family: Farrington
+      given: Rebecca
+      sequence: additional
+    - family: Beucher
+      given: Romain
+      sequence: additional
+    - family: Montes
+      given: Camilo
+      sequence: additional
+    - family: Moresi
+      given: Louis
+      sequence: additional
+  container_title:
+    - Geochemistry, Geophysics, Geosystems
+  issue: '11'
+  issued:
+    date_parts:
+      - - 2022
+        - 11
+  title:
+    - The Role of Lithospheric‐Deep Mantle Interactions on the Style and Stress Evolution
+      of Arc‐Continent Collision
+  type: journal-article
+  volume: '23'
 compute_info:
   computer_name: Nectar Research Cloud
   organisation: Australian Research Data Commons

--- a/src/pages/models/mather-2022-groundwater/index.md
+++ b/src/pages/models/mather-2022-groundwater/index.md
@@ -52,11 +52,39 @@ authors:
     ORCID: 0000-0003-3685-174X
     affiliation: Research School of Earth Sciences, Australian National University
 associated_publication:
-  title: Scientific Reports
-  journal: Nature
-  publisher: Springer Nature
-  doi: 10.1038/s41598-022-08384-w
-  url: https://www.nature.com/articles/s41598-022-08384-w
+  DOI: 10.1038/s41598-022-08384-w
+  URL: http://dx.doi.org/10.1038/s41598-022-08384-w
+  author:
+    - family: Mather
+      given: Ben
+      sequence: first
+    - family: Müller
+      given: R. Dietmar
+      sequence: additional
+    - family: O’Neill
+      given: Craig
+      sequence: additional
+    - family: Beall
+      given: Adam
+      sequence: additional
+    - family: Vervoort
+      given: R. Willem
+      sequence: additional
+    - family: Moresi
+      given: Louis
+      sequence: additional
+  container_title:
+    - Scientific Reports
+  issue: '1'
+  issued:
+    date_parts:
+      - - 2022
+        - 3
+        - 16
+  title:
+    - Constraining the response of continental-scale groundwater flow to climate change
+  type: journal-article
+  volume: '12'
 compute_info:
   computer_name:
   organisation:

--- a/src/pages/models/polanco-2023-deltas/index.md
+++ b/src/pages/models/polanco-2023-deltas/index.md
@@ -62,11 +62,47 @@ authors:
     ORCID: 0000-0003-3685-174X
     affiliation: Australian National University, Canberra, ACT, AU
 associated_publication:
-  title: The flexural isostatic response of climatically driven sea-level changes on continental-scale deltas
-  journal: EGUsphere
-  publisher: Copernicus Publications
-  doi: 10.5194/egusphere-2023-53
-  url: https://egusphere.copernicus.org/preprints/2023/egusphere-2023-53/
+  DOI: 10.5194/egusphere-2023-53
+  URL: http://dx.doi.org/10.5194/egusphere-2023-53
+  author:
+    - family: Polanco
+      given: Sara
+      sequence: first
+    - family: Blum
+      given: Mike
+      sequence: additional
+    - family: Salles
+      given: Tristan
+      sequence: additional
+    - family: Frederick
+      given: Bruce C.
+      sequence: additional
+    - family: Farrington
+      given: Rebecca
+      sequence: additional
+    - family: Ding
+      given: Xuesong
+      sequence: additional
+    - family: Mather
+      given: Ben
+      sequence: additional
+    - family: Mallard
+      given: Claire
+      sequence: additional
+    - family: Moresi
+      given: Louis
+      sequence: additional
+  container_title:
+    - "EGUsphere [preprint]"
+  issued:
+    date_parts:
+      - - 2023
+        - 3
+        - 3
+  title:
+    - The flexural isostatic response of climatically driven sea-level changes on continental-scale
+      deltas
+  type: journal-article
 compute_info:
   computer_name:
   organisation:

--- a/src/pages/models/sandiford-2021-detachment/index.md
+++ b/src/pages/models/sandiford-2021-detachment/index.md
@@ -44,11 +44,36 @@ authors:
     ORCID: 0000-0002-3170-3935
     affiliation: Institute for Marine and Antarctic Studies University of Tasmania  Hobart TAS Australia
 associated_publication:
-  title: "Kinematics of footwall exhumation at oceanic detachment faults: solid‐block rotation and apparent unbending"
-  journal: Geochemistry, Geophysics, Geosystems
-  publisher: American Geophysical Union
-  doi: 10.1029/2021GC009681
-  url: https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2021GC009681
+  DOI: 10.1029/2021gc009681
+  URL: http://dx.doi.org/10.1029/2021gc009681
+  author:
+    - family: Sandiford
+      given: Dan
+      sequence: first
+    - family: Brune
+      given: Sascha
+      sequence: additional
+    - family: Glerum
+      given: Anne
+      sequence: additional
+    - family: Naliboff
+      given: John
+      sequence: additional
+    - family: Whittaker
+      given: Joanne M.
+      sequence: additional
+  container_title:
+    - Geochemistry, Geophysics, Geosystems
+  issue: '4'
+  issued:
+    date_parts:
+      - - 2021
+        - 4
+  title:
+    - 'Kinematics of Footwall Exhumation at Oceanic Detachment faults: Solid‐Block Rotation
+      and Apparent Unbending'
+  type: journal-article
+  volume: '22'
 compute_info:
   computer_name: LISE
   organisation: Nationales Hochleistungsrechnen – NHR

--- a/src/templates/model.js
+++ b/src/templates/model.js
@@ -11,6 +11,7 @@ import {
   BadgeDoi,
   TagsList,
 } from "../components/Badges"
+import Citation from "../components/Citation"
 import Content, { HTMLContent } from "../components/Content"
 import PageHead from "../components/Head"
 import Layout from "../components/Layout"
@@ -31,6 +32,7 @@ const ModelTemplate = ({
   model_files,
   model_setup,
   model_setup_info,
+  publication,
   research_tags,
   title,
 }) => {
@@ -113,11 +115,25 @@ const ModelTemplate = ({
           <TabPanel key="overview">
             <h2>Abstract</h2>
             <p>{abstract}</p>
-            <h3>Tags</h3>
+            {
+              publication &&
+              <>
+                <h2>Publication</h2>
+                {
+                  publication.DOI &&
+                  <BadgeDoi
+                    doi={publication.DOI}
+                    style={{marginBottom: "10px"}}
+                  />
+                }
+                <Citation data={publication}/>
+              </>
+            }
+            <h2>Tags</h2>
             <p><TagsList tags={all_tags}/></p>
             {graphic_abstract &&
               <div>
-                <h3>Graphic abstract</h3>
+                <h2>Graphic abstract</h2>
                 <PreviewCompatibleImage
                   imageInfo={{
                   image: graphic_abstract.src,
@@ -138,7 +154,7 @@ const ModelTemplate = ({
             {
               model_setup?.src &&
               <div>
-                <h3>Model setup</h3>
+                <h2>Model setup</h2>
                 <PreviewCompatibleImage
                   imageInfo={{
                     image: model_setup.src,
@@ -148,6 +164,10 @@ const ModelTemplate = ({
                     ),
                   }}
                 />
+                {
+                  model_setup.caption &&
+                  <p>{model_setup.caption}</p>
+                }
               </div>
             }
             {
@@ -174,7 +194,7 @@ const ModelTemplate = ({
             {
               model_files?.notes &&
               <div>
-                <h3>Notes</h3>
+                <h3>Notes on model files</h3>
                 <p>{model_files.notes}</p>
               </div>
             }
@@ -207,12 +227,18 @@ const ModelTemplate = ({
                 <h3 style={{paddingBottom: "30px"}}>Animations</h3>
                 {
                   animations.map((animation, i) => (
-                    <Animation
-                      src={animation.src.publicURL}
-                      alt={animation.caption || "Animation | " + title}
-                      key={i}
-                      controls
-                    />
+                    <p>
+                      <Animation
+                        src={animation.src.publicURL}
+                        alt={animation.caption || "Animation | " + title}
+                        key={i}
+                        controls
+                      />
+                      {
+                        animation.caption &&
+                        <p>{animation.caption}</p>
+                      }
+                    </p>
                   ))
                 }
               </>
@@ -264,6 +290,7 @@ const ModelsPage = ({ data }) => {
         model_files={post.frontmatter.model_files}
         model_setup_info={post.frontmatter.model_setup_info}
         model_setup={post.frontmatter.images.model_setup}
+        publication={post.frontmatter.associated_publication}
         research_tags={post.frontmatter.research_tags}
         title={post.frontmatter.title}
       />
@@ -290,11 +317,21 @@ export const pageQuery = graphql`
           }
         }
         associated_publication {
+          DOI
+          URL
+          author {
+            given
+            family
+            sequence
+          }
+          container_title
+          issue
+          issued {
+            date_parts
+          }
           title
-          journal
-          publisher
-          doi
-          url
+          type
+          volume
         }
         authors {
           name


### PR DESCRIPTION
We need some additional information for the `associated_publication` field to construct the reference. I've added this information for the models we have, and also created [a simple Python script](https://gist.github.com/cpalfonso/2b36d20e3426047294cd566a596fdcac) to fetch the required information from the publication DOI in the future. 