### PR TITLE
Fix kebab-case for tags with symbols

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -102,7 +102,8 @@ exports.createPages = ({ actions, graphql }) => {
 
     // Make tag pages
     tags.forEach((tag) => {
-      const tagPath = `/tags/${_.kebabCase(tag)}/`
+      const tagSlug = tag.toString().toLowerCase().split(/\s/).join("-")
+      const tagPath = `/tags/${tagSlug}/`
 
       createPage({
         path: tagPath,

--- a/src/components/Badges.js
+++ b/src/components/Badges.js
@@ -1,6 +1,5 @@
 import React from "react"
 import { Link } from "gatsby"
-import { kebabCase } from "lodash"
 
 import { getCreatorSlug, cleanDoi } from "./ModelList"
 
@@ -27,8 +26,9 @@ const BadgeDoi = ({ doi, style }) => {
 }
 
 const BadgeTag = ({ tag, style }) => {
+  const slug = tag.toString().toLowerCase().split(/\s/).join("-")
   return (
-    <Link to={`/tags/${kebabCase(tag)}`}>
+    <Link to={`/tags/${slug}`}>
       <span className="badge-tag hover-shadow hover-opacity" style={style}>{tag}</span>
     </Link>
   )

--- a/src/pages/creators/index.js
+++ b/src/pages/creators/index.js
@@ -1,5 +1,5 @@
 import { Link, graphql } from "gatsby"
-import { get, kebabCase } from "lodash"
+import { get } from "lodash"
 import React from "react"
 
 import PageHead from "../../components/Head"

--- a/src/pages/tags/index.js
+++ b/src/pages/tags/index.js
@@ -1,7 +1,6 @@
 import React from "react";
 import {
   get,
-  kebabCase,
   toLower,
   upperFirst,
   words,
@@ -83,7 +82,7 @@ const TagsPage = ({
               <ul className="taglist">
                 {tags.map((tag) => (
                   <li key={tag}>
-                    <Link to={`/tags/${kebabCase(tag)}/`}>
+                    <Link to={`/tags/${tag.toString().toLowerCase().split(/\s/).join("-")}/`}>
                       {tag} ({post_counts[tag]})
                     </Link>
                   </li>

--- a/src/templates/model.js
+++ b/src/templates/model.js
@@ -1,5 +1,4 @@
 import { graphql } from "gatsby"
-import { kebabCase } from "lodash"
 import PropTypes from "prop-types"
 import React from "react"
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs"


### PR DESCRIPTION
E.g. the tag "C++" will no longer link to "/tags/c"