### PR TITLE
Remove doi.org requests for publications

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -223,21 +223,6 @@ exports.onCreateNode = ({
       node,
       value,
     })
-
-    const doi = node.frontmatter.associated_publication?.doi
-    if (doi) {
-      const citation = new Cite(doi)
-      const html = citation.format("bibliography", {format: "html", style: "apa"})
-      transformObject(
-        {
-          html,
-          doi,
-          data: citation.data[0]
-        },
-        citation.id ? citation.id : createNodeId(`${node.id} citation`),
-        _.upperFirst(_.camelCase(`citation`))
-      )
-    }
   }
 
   if (node.internal.type === `File`) {

--- a/src/components/Citation.js
+++ b/src/components/Citation.js
@@ -48,6 +48,33 @@ const cleanData = (data) => {
   return data
 }
 
+const cleanDOI = (doi) => {
+  const doi_split = doi.split("/")
+  const doi_parts = doi_split.slice(-2)
+  return doi_parts.join("/")
+}
+
+const toCSL = (data) => (
+  {
+    id: cleanDOI(data.doi),
+    type: "article-journal",
+    DOI: cleanDOI(data.doi),
+    issued: { raw: data.date },
+    publisher: data.publisher,
+    page: data.page,
+    volume: data.volume,
+    issue: data.issue,
+    "container-title": data.journal,
+    title: data.title,
+    author: data.authors.map(author => ({
+      "@type": author["@type"],
+      "@id": author["@id"],
+      given: author.name,
+      family: author.family_name,
+    })),
+  }
+)
+
 // Taken from gatsby-source-publications
 // https://github.com/bacor/gatsby-source-publications/blob/main/gatsby-node.mjs#L12
 function replaceDois({ html, style = "apa", target="_blank" }) {
@@ -69,4 +96,4 @@ function replaceDois({ html, style = "apa", target="_blank" }) {
 }
 
 export default Citation
-export { getHtml, replaceDois, cleanData }
+export { getHtml, replaceDois, cleanData, cleanDOI, toCSL }


### PR DESCRIPTION
This PR removes the requests to doi.org for the `associated_publication` field. It also allows for DOIs with or without the URL components. 