### PR TITLE
Use citation-js v.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "bulma": "^0.9.4",
-    "citation-js": "^0.7.4",
+    "citation-js": "^0.6.0",
     "fast-xml-parser": "^4.4.0",
     "gatsby": "^5.8.1",
     "gatsby-adapter-netlify": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
+    "ajv": "~8.13.0",
     "bulma": "^0.9.4",
     "citation-js": "^0.6.0",
     "fast-xml-parser": "^4.4.0",


### PR DESCRIPTION
This should prevent more Netlify errors (e.g. [https://app.netlify.com/projects/mate-science/deploys/68e856d6a704a3cdb7a6a272](https://app.netlify.com/projects/mate-science/deploys/68e856d6a704a3cdb7a6a272)).